### PR TITLE
Add an example of using GENERATE(table())

### DIFF
--- a/docs/list-of-examples.md
+++ b/docs/list-of-examples.md
@@ -16,6 +16,7 @@
 - Configuration: [Provide your own output streams](../examples/231-Cfg-OutputStreams.cpp)
 - Generators: [Create your own generator](../examples/300-Gen-OwnGenerator.cpp)
 - Generators: [Use map to convert types in GENERATE expression](../examples/301-Gen-MapTypeConversion.cpp)
+- Generators: [Run test with a table of input values](../examples/302-Gen-Table.cpp)
 - Generators: [Use variables in generator expressions](../examples/310-Gen-VariablesInGenerators.cpp)
 - Generators: [Use custom variable capture in generator expressions](../examples/311-Gen-CustomCapture.cpp)
 

--- a/examples/302-Gen-Table.cpp
+++ b/examples/302-Gen-Table.cpp
@@ -1,0 +1,54 @@
+// 302-Gen-Table.cpp
+// Shows how to use table to run a test many times with different inputs. Lifted from examples on
+// issue #850.
+
+#include <catch2/catch.hpp>
+#include <string>
+
+struct TestSubject {
+    // this is the method we are going to test. It returns the length of the
+    // input string.
+    size_t GetLength( const std::string& input ) const { return input.size(); }
+};
+
+
+TEST_CASE("Table allows pre-computed test inputs and outputs", "[example][generator]") {
+    using std::make_tuple;
+    // do setup here as normal
+    TestSubject subj;
+
+    SECTION("This section is run for each row in the table") {
+        std::string test_input;
+        size_t expected_output;
+        std::tie( test_input, expected_output ) =
+            GENERATE( table<std::string, size_t>(
+                { /* In this case one of the parameters to our test case is the
+                   * expected output, but this is not required. There could be
+                   * multiple expected values in the table, which can have any
+                   * (fixed) number of columns.
+                   */
+                  make_tuple( "one", 3 ),
+                  make_tuple( "two", 3 ),
+                  make_tuple( "three", 5 ),
+                  make_tuple( "four", 4 ) } ) );
+
+        // run the test
+        auto result = subj.GetLength(test_input);
+        // capture the input data to go with the outputs.
+        CAPTURE(test_input);
+        // check it matches the pre-calculated data
+        REQUIRE(result == expected_output);
+    }   // end section
+}
+
+/* Possible simplifications where less legacy toolchain support is needed:
+ *
+ * - With libstdc++6 or newer, the make_tuple() calls can be ommitted
+ * (technically C++17 but does not require -std in GCC/Clang). See
+ *   https://stackoverflow.com/questions/12436586/tuple-vector-and-initializer-list
+ *
+ * - In C++17 mode std::tie() and the preceeding variable delcarations can be
+ * replaced by structured bindings: auto [test_input, expected] = GENERATE(
+ * table<std::string, size_t>({ ...
+ */
+// Compiling and running this file will result in 4 successful assertions

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -46,6 +46,7 @@ set( SOURCES_IDIOMATIC_TESTS
     210-Evt-EventListeners.cpp
     300-Gen-OwnGenerator.cpp
     301-Gen-MapTypeConversion.cpp
+    302-Gen-Table.cpp
     310-Gen-VariablesInGenerators.cpp
     311-Gen-CustomCapture.cpp
 )


### PR DESCRIPTION
There are some examples on issue #850 of using this feature, but they
are not easily found from the documentation. Adding them here as an
example makes them more findable and ensures they keep working if the
API changes.

<!--
Please do not submit pull requests changing the `version.hpp`
or the single-include `catch.hpp` file, these are changed
only when a new release is made.

Before submitting a PR you should probably read the contributor documentation
at docs/contributing.md. It will tell you how to properly test your changes.
-->


## Description
<!--
Describe the what and the why of your pull request. Remember that these two
are usually a bit different. As an example, if you have made various changes
to decrease the number of new strings allocated, that's what. The why probably
was that you have a large set of tests and found that this speeds them up.
-->

## GitHub Issues
<!-- 
If this PR was motivated by some existing issues, reference them here.

If it is a simple bug-fix, please also add a line like 'Closes #123'
to your commit message, so that it is automatically closed.
If it is not, don't, as it might take several iterations for a feature
to be done properly. If in doubt, leave it open and reference it in the
PR itself, so that maintainers can decide.
-->
